### PR TITLE
YAML-based config & path rewrites

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [l3uddz, m-rots]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.x'
+      - name: Run tests
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 *.db
 /autoscan
+/config.yml

--- a/autoscan.go
+++ b/autoscan.go
@@ -1,6 +1,10 @@
 package autoscan
 
-import "net/http"
+import (
+	"net/http"
+	"path"
+	"strings"
+)
 
 // A Scan is at the core of Autoscan.
 // It defines which path to scan and with which (trigger-given) priority.
@@ -12,9 +16,33 @@ type Scan struct {
 	Metadata Metadata
 }
 
+// Metadata is an optional extension to autoscan.Scan.
+// It defines the provider (e.g. IMDb or TVDb) and the corresponding ID.
+//
+// Metadata MAY be used by targets to get a perfect match.
 type Metadata struct {
 	Provider string
 	ID       string
+}
+
+// BaseConfig defines the base config all Triggers and Targets MUST support.
+type BaseConfig struct {
+	AddPrefix   string `yaml:"addPrefix"`
+	StripPrefix string `yaml:"stripPrefix"`
+}
+
+// TriggerConfig extends the BaseConfig and adds Trigger-specific fields.
+type TriggerConfig struct {
+	BaseConfig `yaml:",inline"`
+	Priority   int `yaml:"priority"`
+}
+
+// HTTPTriggerConfig extends the TriggerConfig and adds HTTP-related fields.
+type HTTPTriggerConfig struct {
+	TriggerConfig `yaml:",inline"`
+
+	// Name MUST be used by the router to separate instances of the same trigger.
+	Name string `yaml:"name"`
 }
 
 // A Trigger pushes new Scans to the given channel.
@@ -37,7 +65,24 @@ type HTTPTrigger func(chan Scan) http.Handler
 type Target func(Scan)
 
 const (
+	// TVDb provider for use in autoscan.Metadata
 	TVDb = "tvdb"
+
+	// TMDb provider for use in autoscan.Metadata
 	TMDb = "tmdb"
+
+	// IMDb provider for use in autoscan.Metadata
 	IMDb = "imdb"
 )
+
+// AddPrefix adds the specified prefix to the given path.
+// If the prefix does not start with the slash, it gets added.
+func AddPrefix(prefix string, p string) string {
+	return path.Join("/", prefix, p)
+}
+
+// StripPrefix removes the specified prefix from the given path.
+// A slash at the end of the prefix will be ignored.
+func StripPrefix(prefix string, p string) string {
+	return path.Join("/", strings.TrimPrefix(p, prefix))
+}

--- a/autoscan_test.go
+++ b/autoscan_test.go
@@ -1,0 +1,87 @@
+package autoscan
+
+import "testing"
+
+func TestAddPrefix(t *testing.T) {
+	type Test struct {
+		Name     string
+		Prefix   string
+		Path     string
+		Expected string
+	}
+
+	var testCases = []Test{
+		{
+			Name:     "Normal case",
+			Prefix:   "/mnt/unionfs",
+			Path:     "/Media/Movies",
+			Expected: "/mnt/unionfs/Media/Movies",
+		},
+		{
+			Name:     "Slash at the end of the path is dropped",
+			Prefix:   "/mnt/",
+			Path:     "media/movies/",
+			Expected: "/mnt/media/movies",
+		},
+		{
+			Name:     "Empty prefix does not affect path",
+			Prefix:   "",
+			Path:     "/media/movies",
+			Expected: "/media/movies",
+		},
+		{
+			Name:     "Prefix without slash is rewritten to include the slash",
+			Prefix:   "mnt/unionfs",
+			Path:     "/media/movies",
+			Expected: "/mnt/unionfs/media/movies",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Expected, func(t *testing.T) {
+			result := AddPrefix(tc.Prefix, tc.Path)
+			if result != tc.Expected {
+				t.Errorf("%s does not equal %s", result, tc.Expected)
+			}
+		})
+	}
+}
+
+func TestStripPrefix(t *testing.T) {
+	type Test struct {
+		Name     string
+		Prefix   string
+		Path     string
+		Expected string
+	}
+
+	var testCases = []Test{
+		{
+			Name:     "Normal case",
+			Prefix:   "/mnt/unionfs",
+			Path:     "/mnt/unionfs/Movies/movie",
+			Expected: "/Movies/movie",
+		},
+		{
+			Name:     "Slash is added in front",
+			Prefix:   "/hello/",
+			Path:     "/hello/world",
+			Expected: "/world",
+		},
+		{
+			Name:     "Empty prefix does not affect path",
+			Prefix:   "",
+			Path:     "/hello/world",
+			Expected: "/hello/world",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Expected, func(t *testing.T) {
+			result := StripPrefix(tc.Prefix, tc.Path)
+			if result != tc.Expected {
+				t.Errorf("%s does not equal %s", result, tc.Expected)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/cloudbox/autoscan
 
 go 1.14
 
-require github.com/mattn/go-sqlite3 v1.14.0
+require (
+	github.com/mattn/go-sqlite3 v1.14.0
+	gopkg.in/yaml.v2 v2.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -9,3 +9,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/triggers/radarr/radarr.go
+++ b/triggers/radarr/radarr.go
@@ -10,16 +10,19 @@ import (
 )
 
 // New creates an autoscan-compatible HTTP Trigger for Radarr webhooks.
-//
-// TODO: New should accept a Radarr-specific path rewriter.
-func New() autoscan.HTTPTrigger {
+func New(c Config) autoscan.HTTPTrigger {
 	return func(scans chan autoscan.Scan) http.Handler {
-		return &handler{scans: scans}
+		return &handler{config: c, scans: scans}
 	}
 }
 
+type Config struct {
+	autoscan.HTTPTriggerConfig `yaml:",inline"`
+}
+
 type handler struct {
-	scans chan autoscan.Scan
+	config Config
+	scans  chan autoscan.Scan
 }
 
 type radarrEvent struct {
@@ -61,10 +64,19 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Rewrite the path based on the path-rewriter in the handler struct.
+	// Rewrite the path based on the provided AddPrefix and StripPrefix values.
+	filePath := path.Join(event.Movie.FolderPath, event.File.RelativePath)
+	if h.config.StripPrefix != "" {
+		filePath = autoscan.StripPrefix(h.config.StripPrefix, filePath)
+	}
+
+	if h.config.AddPrefix != "" {
+		filePath = autoscan.AddPrefix(h.config.AddPrefix, filePath)
+	}
+
 	scan := autoscan.Scan{
-		Path:     path.Join(event.Movie.FolderPath, event.File.RelativePath),
-		Priority: 1,
+		Path:     filePath,
+		Priority: h.config.Priority,
 	}
 
 	if event.Details.ImdbID != "" {


### PR DESCRIPTION
This pull request features:
- YAML based config
- Paths can have a prefix stripped and added
- Initial Github Actions test suite support

### Config Example
```yml
triggers:
  sonarr:
    - name: sonarr4k
      priority: 3
      stripPrefix: /mnt/unionfs
      addPrefix: /4k
    - name: sonarr
      priority: 2
      stripPrefix: /mnt/unionfs
  radarr:
    - name: radarr
      priority: 2
      stripPrefix: /mnt/unionfs
```

### Supported config fields

Priority, AddPrefix and StripPrefix can now be set from the config to change the behaviour of the triggers.
Sonarr and Radarr now use the HTTPTriggerConfig, which might get more options in the future.

### Different configs

- BaseConfig
BaseConfig defines all the fields which must be supported by all triggers and targets. Thus far the BaseConfig consists of AddPrefix and StripPrefix as those are essential to both triggers and targets to rewrite paths correctly.
- TriggerConfig
TriggerConfig adds the Priority field, which defines what priority level a certain trigger has. This priority level will be used by the processor to pick more important jobs at first.
- HTTPTriggerConfig
HTTPTriggerConfig adds the Name field, which defines what URL the handler will be available from. All handlers will be accessible from `/triggers/{name}`. Duplicate values across different triggers causes the router to panic.