### PR TITLE
Anchor files

### DIFF
--- a/autoscan.go
+++ b/autoscan.go
@@ -71,6 +71,11 @@ var (
 	// ErrNoScans is not an error. It only indicates whether the CLI
 	// should sleep longer depending on the processor output.
 	ErrNoScans = errors.New("no scans currently available")
+
+	// ErrAnchorUnavailable indicates that an Anchor file is
+	// not available on the file system. Processing should halt
+	// until all anchors are available.
+	ErrAnchorUnavailable = errors.New("anchor file is unavailable")
 )
 
 type Rewrite struct {


### PR DESCRIPTION
Anchor files make sure all mounts (if any) are up by checking whether a specific file can be accessed.

- End users SHOULD add multiple anchor files when using multiple mounts.
- End users SHOULD use the MergerFS/UnionFS path instead of directly accessing the mount.

Anchor files can be set from the config:
```yaml
anchors:
  - /mnt/unionfs/anchor
```