### PR TITLE
feat(triggers): basic authentication

### DIFF
--- a/triggers/radarr/radarr.go
+++ b/triggers/radarr/radarr.go
@@ -7,10 +7,8 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/rs/zerolog/hlog"
-
 	"github.com/cloudbox/autoscan"
-	"github.com/cloudbox/autoscan/triggers"
+	"github.com/rs/zerolog/hlog"
 )
 
 type Config struct {
@@ -27,15 +25,12 @@ func New(c Config) (autoscan.HTTPTrigger, error) {
 		return nil, err
 	}
 
-	log := autoscan.GetLogger(c.Verbosity)
-	logHandler := triggers.WithLogger(log)
-
 	trigger := func(callback autoscan.ProcessorFunc) http.Handler {
-		return logHandler(handler{
+		return handler{
 			callback: callback,
 			priority: c.Priority,
 			rewrite:  rewriter,
-		})
+		}
 	}
 
 	return trigger, nil

--- a/triggers/sonarr/sonarr.go
+++ b/triggers/sonarr/sonarr.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/cloudbox/autoscan"
-	"github.com/cloudbox/autoscan/triggers"
 	"github.com/rs/zerolog/hlog"
 )
 
@@ -26,15 +25,12 @@ func New(c Config) (autoscan.HTTPTrigger, error) {
 		return nil, err
 	}
 
-	log := autoscan.GetLogger(c.Verbosity)
-	logHandler := triggers.WithLogger(log)
-
 	trigger := func(callback autoscan.ProcessorFunc) http.Handler {
-		return logHandler(handler{
+		return handler{
 			callback: callback,
 			priority: c.Priority,
 			rewrite:  rewriter,
-		})
+		}
 	}
 
 	return trigger, nil


### PR DESCRIPTION
This PR adds optional basic authentication to the HTTPTriggers Sonarr and Radarr.

### Notable changes

- A warning is displayed if at least one http trigger is enabled and no username or password is set.
- `triggers.WithLogger` is now used within the cmd module (previously set in http triggers).
- Adds a new `triggers.WithAuth` middleware which accepts a username and password.
If either one is missing the middleware is **not** applied.
- Successful authentication will display in the http trigger's trace log.
- Unsuccessful authentication will display as a warning.

### New config section

The `authentication` field only applies to HTTPTriggers.

```yaml
authentication:
  username: hello there
  password: general kenobi
```

