### PR TITLE
refactor: remove scan size and metadata

### DIFF
--- a/autoscan.go
+++ b/autoscan.go
@@ -13,19 +13,8 @@ import (
 type Scan struct {
 	Folder   string
 	File     string
-	Size     uint64
 	Priority int
 	Retries  int
-	Metadata Metadata
-}
-
-// Metadata is an optional extension to autoscan.Scan.
-// It defines the provider (e.g. IMDb or TVDb) and the corresponding ID.
-//
-// Metadata MAY be used by targets to get a perfect match.
-type Metadata struct {
-	Provider string
-	ID       string
 }
 
 type ProcessorFunc func(...Scan) error

--- a/triggers/lidarr/lidarr.go
+++ b/triggers/lidarr/lidarr.go
@@ -3,7 +3,6 @@ package lidarr
 import (
 	"encoding/json"
 	"net/http"
-	"os"
 	"path"
 
 	"github.com/cloudbox/autoscan"
@@ -87,23 +86,10 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		// Rewrite the path based on the provided rewriter.
 		fullPath := h.rewrite(f.Path)
 
-		// Retrieve the size of the file.
-		size, err := fileSize(fullPath)
-		if err != nil {
-			l.Warn().
-				Err(err).
-				Str("path", fullPath).
-				Msg("File does not exist")
-
-			rw.WriteHeader(http.StatusNotFound)
-			return
-		}
-
 		scans = append(scans, autoscan.Scan{
 			File:     path.Base(fullPath),
 			Folder:   path.Dir(fullPath),
 			Priority: h.priority,
-			Size:     size,
 		})
 	}
 
@@ -119,13 +105,4 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		Str("path", h.rewrite(event.Artist.Path)).
 		Int("files", len(scans)).
 		Msg("Scan moved to processor")
-}
-
-var fileSize = func(name string) (uint64, error) {
-	info, err := os.Stat(name)
-	if err != nil {
-		return 0, err
-	}
-
-	return uint64(info.Size()), nil
 }

--- a/triggers/lidarr/lidarr_test.go
+++ b/triggers/lidarr/lidarr_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -16,7 +15,6 @@ func TestHandler(t *testing.T) {
 	type Given struct {
 		Config  Config
 		Fixture string
-		Sizes   map[string]uint64
 	}
 
 	type Expected struct {
@@ -45,12 +43,6 @@ func TestHandler(t *testing.T) {
 			Given{
 				Config:  standardConfig,
 				Fixture: "testdata/marshmello.json",
-				Sizes: map[string]uint64{
-					"01 - Down.mp3":            100,
-					"02 - Run It Up.mp3":       500,
-					"03 - Put Yo Hands Up.mp3": 200,
-					"04 - Let’s Get Down.mp3":  1200,
-				},
 			},
 			Expected{
 				StatusCode: 200,
@@ -59,25 +51,21 @@ func TestHandler(t *testing.T) {
 						File:     "01 - Down.mp3",
 						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
 						Priority: 5,
-						Size:     100,
 					},
 					{
 						File:     "02 - Run It Up.mp3",
 						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
 						Priority: 5,
-						Size:     500,
 					},
 					{
 						File:     "03 - Put Yo Hands Up.mp3",
 						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
 						Priority: 5,
-						Size:     200,
 					},
 					{
 						File:     "04 - Let’s Get Down.mp3",
 						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
 						Priority: 5,
-						Size:     1200,
 					},
 				},
 			},
@@ -106,10 +94,6 @@ func TestHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			fileSize = func(name string) (uint64, error) {
-				return tc.Given.Sizes[filepath.Base(name)], nil
-			}
-
 			callback := func(scans ...autoscan.Scan) error {
 				if !reflect.DeepEqual(tc.Expected.Scans, scans) {
 					t.Log(scans)

--- a/triggers/radarr/radarr_test.go
+++ b/triggers/radarr/radarr_test.go
@@ -15,7 +15,6 @@ func TestHandler(t *testing.T) {
 	type Given struct {
 		Config  Config
 		Fixture string
-		Size    uint64
 	}
 
 	type Expected struct {
@@ -44,20 +43,14 @@ func TestHandler(t *testing.T) {
 			Given{
 				Config:  standardConfig,
 				Fixture: "testdata/interstellar.json",
-				Size:    157336,
 			},
 			Expected{
 				StatusCode: 200,
 				Scans: []autoscan.Scan{
 					{
-						File:   "Interstellar.2014.UHD.BluRay.2160p.REMUX.mkv",
-						Folder: "/mnt/unionfs/Media/Movies/Interstellar (2014)",
-						Metadata: autoscan.Metadata{
-							ID:       "tt0816692",
-							Provider: autoscan.IMDb,
-						},
+						File:     "Interstellar.2014.UHD.BluRay.2160p.REMUX.mkv",
+						Folder:   "/mnt/unionfs/Media/Movies/Interstellar (2014)",
 						Priority: 5,
-						Size:     157336,
 					},
 				},
 			},
@@ -74,20 +67,14 @@ func TestHandler(t *testing.T) {
 					},
 				},
 				Fixture: "testdata/parasite.json",
-				Size:    200000,
 			},
 			Expected{
 				StatusCode: 200,
 				Scans: []autoscan.Scan{
 					{
-						File:   "Parasite.2019.2160p.UHD.BluRay.REMUX.HEVC.TrueHD.Atmos.7.1.mkv",
-						Folder: "/Media/Movies/Parasite (2019)",
-						Metadata: autoscan.Metadata{
-							ID:       "496243",
-							Provider: autoscan.TMDb,
-						},
+						File:     "Parasite.2019.2160p.UHD.BluRay.REMUX.HEVC.TrueHD.Atmos.7.1.mkv",
+						Folder:   "/Media/Movies/Parasite (2019)",
 						Priority: 3,
-						Size:     200000,
 					},
 				},
 			},
@@ -116,10 +103,6 @@ func TestHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			fileSize = func(name string) (uint64, error) {
-				return tc.Given.Size, nil
-			}
-
 			callback := func(scans ...autoscan.Scan) error {
 				if !reflect.DeepEqual(tc.Expected.Scans, scans) {
 					t.Log(scans)

--- a/triggers/sonarr/sonarr_test.go
+++ b/triggers/sonarr/sonarr_test.go
@@ -15,7 +15,6 @@ func TestHandler(t *testing.T) {
 	type Given struct {
 		Config  Config
 		Fixture string
-		Size    uint64
 	}
 
 	type Expected struct {
@@ -44,20 +43,14 @@ func TestHandler(t *testing.T) {
 			Given{
 				Config:  standardConfig,
 				Fixture: "testdata/westworld.json",
-				Size:    38943275,
 			},
 			Expected{
 				StatusCode: 200,
 				Scans: []autoscan.Scan{
 					{
-						File:   "Westworld.S01E01.The.Original.2160p.TrueHD.Atmos.7.1.HEVC.REMUX.mkv",
-						Folder: "/mnt/unionfs/Media/TV/Westworld/Season 1",
-						Metadata: autoscan.Metadata{
-							ID:       "296762",
-							Provider: autoscan.TVDb,
-						},
+						File:     "Westworld.S01E01.The.Original.2160p.TrueHD.Atmos.7.1.HEVC.REMUX.mkv",
+						Folder:   "/mnt/unionfs/Media/TV/Westworld/Season 1",
 						Priority: 5,
-						Size:     38943275,
 					},
 				},
 			},
@@ -86,10 +79,6 @@ func TestHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			fileSize = func(name string) (uint64, error) {
-				return tc.Given.Size, nil
-			}
-
 			callback := func(scans ...autoscan.Scan) error {
 				if !reflect.DeepEqual(tc.Expected.Scans, scans) {
 					t.Log(scans)


### PR DESCRIPTION
This pull request removes the `size` and `metadata` fields from the `autoscan.Scan` struct.

### Reasoning

The `size` field was used to check whether a file had been updated (against the plex/emby database), however, this behaviour was removed in #24 and #25.

The `metadata` field has not been used since its introduction. While we thought it could have been useful, we have decided not to fix metadata from within Autoscan.