### PR TITLE
build(ci): adjust artefact cron to daily

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -2,8 +2,8 @@ name: Remove old artifacts
 
 on:
   schedule:
-    # Every hour
-    - cron: '0 * * * *'
+    # Every every day at 02:00 (UTC)
+    - cron: '0 2 * * *'
 
 jobs:
   remove-old-artifacts:
@@ -15,4 +15,4 @@ jobs:
         uses: c-hive/gha-remove-artifacts@v1
         with:
           age: '1 days'
-          skip-recent: 5
+          skip-recent: 3


### PR DESCRIPTION
Instead of running every hour, this PR adjusts the cron to run once a day at 02:00 UTC time to avoid rate limits.
In addition, only the most recent three artefacts are kept instead of the most recent five artefacts.