### PR TITLE
fix(trigger/bernard): dont try and retrieve the folder path for a drive id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/justinas/alice v1.2.0
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/m-rots/bernard v0.3.3-0.20200804121414-38394a889536
-	github.com/m-rots/stubbs v1.0.1-0.20200804111142-55ef5d1857d9
+	github.com/m-rots/stubbs v1.1.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/m-rots/bernard v0.3.3-0.20200804121414-38394a889536 h1:0aY4VrX9R+Y0VA
 github.com/m-rots/bernard v0.3.3-0.20200804121414-38394a889536/go.mod h1:yDQffALXQDh6sTXdFCbI2rJtYuXgx41MyJM6Sf/j7Sc=
 github.com/m-rots/stubbs v1.0.0 h1:lBrjn27J32/iGHp7eKPYGcphuqDIg5UIs/YI4q1m63Q=
 github.com/m-rots/stubbs v1.0.0/go.mod h1:iDS6z2oonw2UMo2l0S1WTPJ9git7FWU4YEo6fq7F2WU=
-github.com/m-rots/stubbs v1.0.1-0.20200804111142-55ef5d1857d9 h1:ent/Dhpzz7hiCBiDgJL2iS5G0Yzd/a9GpP6XSOet0Qc=
-github.com/m-rots/stubbs v1.0.1-0.20200804111142-55ef5d1857d9/go.mod h1:Ive+DY/P1EikQ644M3tuyvsO/7ohPLnmEru2L+6hbVw=
+github.com/m-rots/stubbs v1.1.0 h1:QR1LHxFYPasju/sEO0KLmI5/RADF70CW3ZtisCs7XrQ=
+github.com/m-rots/stubbs v1.1.0/go.mod h1:Ive+DY/P1EikQ644M3tuyvsO/7ohPLnmEru2L+6hbVw=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=

--- a/triggers/bernard/bernard.go
+++ b/triggers/bernard/bernard.go
@@ -44,7 +44,7 @@ func New(c Config) (autoscan.Trigger, error) {
 		Logger()
 
 	const scope = "https://www.googleapis.com/auth/drive.readonly"
-	auth, err := stubbs.FromFile(c.AccountPath, []string{scope}, 3600)
+	auth, err := stubbs.FromFile(c.AccountPath, []string{scope})
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", err, autoscan.ErrFatal)
 	}

--- a/triggers/bernard/paths.go
+++ b/triggers/bernard/paths.go
@@ -25,7 +25,7 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 		for _, f := range diff.AddedFiles {
 			p, err := getFolderPath(store, driveID, f.Parent, folderMaps.Current)
 			if err != nil {
-				return fmt.Errorf("failed building file path for added file %v: %w", f.ID, err)
+				return fmt.Errorf("building file path for added file %v: %w", f.ID, err)
 			}
 
 			paths.AddedFiles = append(paths.AddedFiles, filepath.Join(p, f.Name))
@@ -36,7 +36,7 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 			// new path
 			p, err := getFolderPath(store, driveID, f.New.Parent, folderMaps.Current)
 			if err != nil {
-				return fmt.Errorf("failed building file path for changed file %v: %w", f.New.ID, err)
+				return fmt.Errorf("building file path for changed file %v: %w", f.New.ID, err)
 			}
 
 			paths.ChangedFiles = append(paths.ChangedFiles, filepath.Join(p, f.New.Name))
@@ -45,7 +45,7 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 			if !f.Old.Trashed && f.Old.ID != "" {
 				p, err := getFolderPath(store, driveID, f.Old.Parent, folderMaps.Old)
 				if err != nil {
-					return fmt.Errorf("failed building removed file path for changed file %v: %w", f.Old.ID, err)
+					return fmt.Errorf("building removed file path for changed file %v: %w", f.Old.ID, err)
 				}
 
 				paths.RemovedFiles = append(paths.RemovedFiles, filepath.Join(p, f.Old.Name))
@@ -56,7 +56,7 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 		for _, f := range diff.RemovedFiles {
 			p, err := getFolderPath(store, driveID, f.Parent, folderMaps.Old)
 			if err != nil {
-				return fmt.Errorf("failed building file path for removed file %v: %w", f.ID, err)
+				return fmt.Errorf("building file path for removed file %v: %w", f.ID, err)
 			}
 
 			paths.RemovedFiles = append(paths.RemovedFiles, filepath.Join(p, f.Name))
@@ -68,14 +68,14 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 		// get changed file paths (descendants of newRoots)
 		changedNewFiles, err := getChangedFolderFiles(store, driveID, newRoots, folderMaps.Current, fileMaps.Current)
 		if err != nil {
-			return fmt.Errorf("failed building changed folder descendant files: %w", err)
+			return fmt.Errorf("building changed folder descendant files: %w", err)
 		}
 
 		for _, f := range changedNewFiles {
 			p, err := getFolderPath(store, driveID, f.Parent, folderMaps.Current)
 			if err != nil {
-				return fmt.Errorf("failed building changed file path for change folder "+
-					"descendant file %v: %w", f.ID, err)
+				return fmt.Errorf("building changed file path for change folder descendant file %v: %w",
+					f.ID, err)
 			}
 
 			paths.ChangedFiles = append(paths.ChangedFiles, filepath.Join(p, f.Name))
@@ -84,7 +84,7 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 		// get descendents of changed folders (old paths - removed)
 		removedOldFiles, err := getChangedFolderFiles(store, driveID, oldRoots, folderMaps.Old, fileMaps.Old)
 		if err != nil {
-			return fmt.Errorf("failed building removed folder descendant files: %w", err)
+			return fmt.Errorf("building removed folder descendant files: %w", err)
 		}
 
 		for _, f := range removedOldFiles {
@@ -94,8 +94,8 @@ func NewPathsHook(driveID string, store *bds, diff *sqlite.Difference) (bernard.
 
 			p, err := getFolderPath(store, driveID, f.Parent, folderMaps.Old)
 			if err != nil {
-				return fmt.Errorf("failed building removed file path for change folder "+
-					"descendant file %v: %w", f.ID, err)
+				return fmt.Errorf("building removed file path for change folder descendant file %v: %w",
+					f.ID, err)
 			}
 
 			paths.RemovedFiles = append(paths.RemovedFiles, filepath.Join(p, f.Name))
@@ -208,6 +208,11 @@ func getDiffFolderMaps(diff *sqlite.Difference) *diffFolderMaps {
 
 func getFolderPath(store *bds, driveId string, folderId string, folderMap map[string]datastore.Folder) (string, error) {
 	path := ""
+
+	// folderId == driveId
+	if folderId == driveId {
+		return path, nil
+	}
 
 	// get top folder
 	topFolder, ok := folderMap[folderId]

--- a/triggers/bernard/postprocess.go
+++ b/triggers/bernard/postprocess.go
@@ -15,7 +15,7 @@ func NewPostProcessBernardDiff(driveID string, store *bds, diff *sqlite.Differen
 
 			ef, err := store.GetFile(driveID, df.ID)
 			if err != nil {
-				return fmt.Errorf("failed retrieving file (id: %v): %w", df.ID, err)
+				return fmt.Errorf("retrieving file (id: %v): %w", df.ID, err)
 			}
 
 			switch {
@@ -32,7 +32,7 @@ func NewPostProcessBernardDiff(driveID string, store *bds, diff *sqlite.Differen
 
 			ef, err := store.GetFolder(driveID, df.ID)
 			if err != nil {
-				return fmt.Errorf("failed retrieving folder (id: %v): %w", df.ID, err)
+				return fmt.Errorf("retrieving folder (id: %v): %w", df.ID, err)
 			}
 
 			switch {


### PR DESCRIPTION
## Summary

Any file creates/changes in the root of a drive, would cause the partial sync to fail while trying to retrieve a folder for it.

This would ultimately fail 5 times before the drive is stopped being monitored.

## Fix

Do not lookup folder paths where the driveId == folderId.

## Misc

Update stubbs to v1.1.0.
Some changes to the error messages bernard produces.