### PR TITLE
refactor: folders of madness

### DIFF
--- a/autoscan.go
+++ b/autoscan.go
@@ -13,10 +13,7 @@ import (
 // The Scan is used across Triggers, Targets and the Processor.
 type Scan struct {
 	Folder   string
-	File     string
 	Priority int
-	Retries  int
-	Removed  bool
 	Time     time.Time
 }
 
@@ -33,20 +30,9 @@ type HTTPTrigger func(ProcessorFunc) http.Handler
 // A Target receives a Scan from the Processor and translates the Scan
 // into a format understood by the target.
 type Target interface {
-	Scan([]Scan) error
+	Scan(Scan) error
 	Available() error
 }
-
-const (
-	// TVDb provider for use in autoscan.Metadata
-	TVDb = "tvdb"
-
-	// TMDb provider for use in autoscan.Metadata
-	TMDb = "tmdb"
-
-	// IMDb provider for use in autoscan.Metadata
-	IMDb = "imdb"
-)
 
 var (
 	// ErrTargetUnavailable may occur when a Target goes offline

--- a/cmd/autoscan/main.go
+++ b/cmd/autoscan/main.go
@@ -9,22 +9,21 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/cloudbox/autoscan/targets/emby"
-
+	"github.com/alecthomas/kong"
+	"github.com/natefinch/lumberjack"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v2"
 
-	"github.com/alecthomas/kong"
 	"github.com/cloudbox/autoscan"
 	"github.com/cloudbox/autoscan/processor"
+	"github.com/cloudbox/autoscan/targets/emby"
 	"github.com/cloudbox/autoscan/targets/plex"
 	"github.com/cloudbox/autoscan/triggers"
 	"github.com/cloudbox/autoscan/triggers/bernard"
 	"github.com/cloudbox/autoscan/triggers/lidarr"
 	"github.com/cloudbox/autoscan/triggers/radarr"
 	"github.com/cloudbox/autoscan/triggers/sonarr"
-	"github.com/natefinch/lumberjack"
 )
 
 type config struct {
@@ -163,7 +162,6 @@ func main() {
 	proc, err := processor.New(processor.Config{
 		Anchors:       c.Anchors,
 		DatastorePath: cli.Database,
-		MaxRetries:    c.MaxRetries,
 		MinimumAge:    c.MinimumAge,
 	})
 

--- a/targets/emby/emby.go
+++ b/targets/emby/emby.go
@@ -62,14 +62,9 @@ func (t target) Available() error {
 	return t.api.Available()
 }
 
-func (t target) Scan(scans []autoscan.Scan) error {
-	// ensure scan tasks present (should never fail)
-	if len(scans) == 0 {
-		return nil
-	}
-
+func (t target) Scan(scan autoscan.Scan) error {
 	// determine library for this scan
-	scanFolder := t.rewrite(scans[0].Folder)
+	scanFolder := t.rewrite(scan.Folder)
 
 	lib, err := t.getScanLibrary(scanFolder)
 	if err != nil {

--- a/targets/plex/plex.go
+++ b/targets/plex/plex.go
@@ -73,14 +73,9 @@ func (t target) Available() error {
 	return err
 }
 
-func (t target) Scan(scans []autoscan.Scan) error {
-	// ensure scan tasks present (should never fail)
-	if len(scans) == 0 {
-		return nil
-	}
-
+func (t target) Scan(scan autoscan.Scan) error {
 	// determine library for this scan
-	scanFolder := t.rewrite(scans[0].Folder)
+	scanFolder := t.rewrite(scan.Folder)
 
 	libs, err := t.getScanLibrary(scanFolder)
 	if err != nil {

--- a/triggers/bernard/bernard.go
+++ b/triggers/bernard/bernard.go
@@ -3,16 +3,17 @@ package bernard
 import (
 	"errors"
 	"fmt"
-	"github.com/robfig/cron/v3"
 	"path/filepath"
 	"time"
 
-	"github.com/cloudbox/autoscan"
 	lowe "github.com/m-rots/bernard"
 	ds "github.com/m-rots/bernard/datastore"
 	"github.com/m-rots/bernard/datastore/sqlite"
 	"github.com/m-rots/stubbs"
+	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
+
+	"github.com/cloudbox/autoscan"
 )
 
 const (
@@ -338,13 +339,10 @@ func (d daemon) getScanTask(drive *drive, paths *Paths) *scanTask {
 		}
 
 		// add scan task
-		dir, file := filepath.Split(rewritten)
+		dir := filepath.Base(rewritten)
 		task.scans = append(task.scans, autoscan.Scan{
 			Folder:   filepath.Clean(dir),
-			File:     file,
 			Priority: d.priority,
-			Retries:  0,
-			Removed:  false,
 			Time:     drive.ScanTime(),
 		})
 
@@ -369,13 +367,10 @@ func (d daemon) getScanTask(drive *drive, paths *Paths) *scanTask {
 		}
 
 		// add scan task
-		dir, file := filepath.Split(filepath.Clean(rewritten))
+		dir := filepath.Base(filepath.Clean(rewritten))
 		task.scans = append(task.scans, autoscan.Scan{
 			Folder:   filepath.Clean(dir),
-			File:     file,
 			Priority: d.priority,
-			Retries:  0,
-			Removed:  false,
 			Time:     drive.ScanTime(),
 		})
 
@@ -400,13 +395,10 @@ func (d daemon) getScanTask(drive *drive, paths *Paths) *scanTask {
 		}
 
 		// add scan task
-		dir, file := filepath.Split(rewritten)
+		dir := filepath.Base(rewritten)
 		task.scans = append(task.scans, autoscan.Scan{
 			Folder:   filepath.Clean(dir),
-			File:     file,
 			Priority: d.priority,
-			Retries:  0,
-			Removed:  true,
 			Time:     drive.ScanTime(),
 		})
 

--- a/triggers/bernard/bernard.go
+++ b/triggers/bernard/bernard.go
@@ -339,7 +339,7 @@ func (d daemon) getScanTask(drive *drive, paths *Paths) *scanTask {
 		}
 
 		// add scan task
-		dir := filepath.Base(rewritten)
+		dir := filepath.Dir(rewritten)
 		task.scans = append(task.scans, autoscan.Scan{
 			Folder:   filepath.Clean(dir),
 			Priority: d.priority,
@@ -367,7 +367,7 @@ func (d daemon) getScanTask(drive *drive, paths *Paths) *scanTask {
 		}
 
 		// add scan task
-		dir := filepath.Base(filepath.Clean(rewritten))
+		dir := filepath.Dir(filepath.Clean(rewritten))
 		task.scans = append(task.scans, autoscan.Scan{
 			Folder:   filepath.Clean(dir),
 			Priority: d.priority,
@@ -395,7 +395,7 @@ func (d daemon) getScanTask(drive *drive, paths *Paths) *scanTask {
 		}
 
 		// add scan task
-		dir := filepath.Base(rewritten)
+		dir := filepath.Dir(rewritten)
 		task.scans = append(task.scans, autoscan.Scan{
 			Folder:   filepath.Clean(dir),
 			Priority: d.priority,

--- a/triggers/lidarr/lidarr_test.go
+++ b/triggers/lidarr/lidarr_test.go
@@ -52,32 +52,11 @@ func TestHandler(t *testing.T) {
 			},
 			Expected{
 				StatusCode: 200,
-				Scans: []autoscan.Scan{
-					{
-						File:     "01 - Down.mp3",
-						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
-						Priority: 5,
-						Time:     currentTime,
-					},
-					{
-						File:     "02 - Run It Up.mp3",
-						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
-						Priority: 5,
-						Time:     currentTime,
-					},
-					{
-						File:     "03 - Put Yo Hands Up.mp3",
-						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
-						Priority: 5,
-						Time:     currentTime,
-					},
-					{
-						File:     "04 - Let’s Get Down.mp3",
-						Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
-						Priority: 5,
-						Time:     currentTime,
-					},
-				},
+				Scans: []autoscan.Scan{{
+					Folder:   "/mnt/unionfs/Media/Music/Marshmello/Joytime III (2019)",
+					Priority: 5,
+					Time:     currentTime,
+				}},
 			},
 		},
 		{

--- a/triggers/radarr/radarr.go
+++ b/triggers/radarr/radarr.go
@@ -81,13 +81,11 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Rewrite the path based on the provided rewriter.
-	fullPath := h.rewrite(path.Join(event.Movie.FolderPath, event.File.RelativePath))
+	folderPath := path.Dir(h.rewrite(path.Join(event.Movie.FolderPath, event.File.RelativePath)))
 
 	scan := autoscan.Scan{
-		File:     path.Base(fullPath),
-		Folder:   path.Dir(fullPath),
+		Folder:   folderPath,
 		Priority: h.priority,
-		Removed:  false,
 		Time:     now(),
 	}
 
@@ -100,7 +98,7 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	rw.WriteHeader(http.StatusOK)
 	rlog.Info().
-		Str("path", fullPath).
+		Str("path", folderPath).
 		Msg("Scan moved to processor")
 }
 

--- a/triggers/radarr/radarr_test.go
+++ b/triggers/radarr/radarr_test.go
@@ -54,7 +54,6 @@ func TestHandler(t *testing.T) {
 				StatusCode: 200,
 				Scans: []autoscan.Scan{
 					{
-						File:     "Interstellar.2014.UHD.BluRay.2160p.REMUX.mkv",
 						Folder:   "/mnt/unionfs/Media/Movies/Interstellar (2014)",
 						Priority: 5,
 						Time:     currentTime,
@@ -79,7 +78,6 @@ func TestHandler(t *testing.T) {
 				StatusCode: 200,
 				Scans: []autoscan.Scan{
 					{
-						File:     "Parasite.2019.2160p.UHD.BluRay.REMUX.HEVC.TrueHD.Atmos.7.1.mkv",
 						Folder:   "/Media/Movies/Parasite (2019)",
 						Priority: 3,
 						Time:     currentTime,

--- a/triggers/sonarr/sonarr.go
+++ b/triggers/sonarr/sonarr.go
@@ -81,13 +81,11 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Rewrite the path based on the provided rewriter.
-	fullPath := h.rewrite(path.Join(event.Series.Path, event.File.RelativePath))
+	folderPath := path.Dir(h.rewrite(path.Join(event.Series.Path, event.File.RelativePath)))
 
 	scan := autoscan.Scan{
-		File:     path.Base(fullPath),
-		Folder:   path.Dir(fullPath),
+		Folder:   folderPath,
 		Priority: h.priority,
-		Removed:  false,
 		Time:     now(),
 	}
 
@@ -100,7 +98,7 @@ func (h handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	rw.WriteHeader(http.StatusOK)
 	rlog.Info().
-		Str("path", fullPath).
+		Str("path", folderPath).
 		Msg("Scan moved to processor")
 }
 

--- a/triggers/sonarr/sonarr_test.go
+++ b/triggers/sonarr/sonarr_test.go
@@ -54,7 +54,6 @@ func TestHandler(t *testing.T) {
 				StatusCode: 200,
 				Scans: []autoscan.Scan{
 					{
-						File:     "Westworld.S01E01.The.Original.2160p.TrueHD.Atmos.7.1.HEVC.REMUX.mkv",
 						Folder:   "/mnt/unionfs/Media/TV/Westworld/Season 1",
 						Priority: 5,
 						Time:     currentTime,


### PR DESCRIPTION
This PR massively simplifies the logic behind Autoscan by dropping the `file`, `retries` and `remove` fields from the Scan struct.
