### PR TITLE
fix(processor): limit db to one connection

### DIFF
--- a/processor/datastore.go
+++ b/processor/datastore.go
@@ -31,6 +31,8 @@ func newDatastore(path string) (*datastore, error) {
 		return nil, err
 	}
 
+	db.SetMaxOpenConns(1)
+
 	_, err = db.Exec(sqlSchema)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Limiting the database to one connection should resolve the `database is locked` which may occur when multiple webhooks are writing at the same time.

Sources:
- [go-sqlite3 discussion](https://github.com/mattn/go-sqlite3/issues/209)