### PR TITLE
feat: add scan-delay configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,16 @@ A snippet of the `config.yml` file:
 # override the minimum age to 30 minutes:
 minimum-age: 30m
 
+# override the delay between processed scans:
+scan-delay: 15s
+
 # set multiple anchor files
 anchors:
   - /mnt/unionfs/drive1.anchor
   - /mnt/unionfs/drive2.anchor
 ```
 
-The `minimum-age` field should be given a string in the following format:
+The `minimum-age` and `scan-delay` fields should be given a string in the following format:
 
 - `1s` if the min-age should be set at 1 second.
 - `5m` if the min-age should be set at 5 minutes.

--- a/cmd/autoscan/main.go
+++ b/cmd/autoscan/main.go
@@ -31,6 +31,7 @@ type config struct {
 	// General configuration
 	Port       int           `yaml:"port"`
 	MinimumAge time.Duration `yaml:"minimum-age"`
+	ScanDelay  time.Duration `yaml:"scan-delay"`
 	Anchors    []string      `yaml:"anchors"`
 
 	// Authentication for autoscan.HTTPTrigger
@@ -147,6 +148,7 @@ func main() {
 	// set default values
 	c := config{
 		MinimumAge: 10 * time.Minute,
+		ScanDelay:  5 * time.Second,
 		Port:       3030,
 	}
 
@@ -334,8 +336,8 @@ func main() {
 		err = proc.Process(targets)
 		switch {
 		case err == nil:
-			// Sleep 5 seconds between successful requests to reduce the load on targets.
-			time.Sleep(5 * time.Second)
+			// Sleep scan-delay between successful requests to reduce the load on targets.
+			time.Sleep(c.ScanDelay)
 
 		case errors.Is(err, autoscan.ErrNoScans):
 			// No scans currently available, let's wait a couple of seconds

--- a/processor/datastore.go
+++ b/processor/datastore.go
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS scan (
 `
 
 func newDatastore(path string) (*datastore, error) {
-	db, err := sql.Open("sqlite3", path)
+	db, err := sql.Open("sqlite3", fmt.Sprintf("%s?%s", path, "cache=shared&mode=rwc&_busy_timeout=5000"))
 	if err != nil {
 		return nil, err
 	}

--- a/triggers/bernard/bernard.go
+++ b/triggers/bernard/bernard.go
@@ -50,10 +50,11 @@ func New(c Config) (autoscan.Trigger, error) {
 		return nil, fmt.Errorf("%v: %w", err, autoscan.ErrFatal)
 	}
 
-	store, err := sqlite.New(c.DatastorePath)
+	store, err := sqlite.New(fmt.Sprintf("%s?%s", c.DatastorePath, "cache=shared&mode=rwc&_busy_timeout=5000"))
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", err, autoscan.ErrFatal)
 	}
+	store.DB.SetMaxOpenConns(1)
 
 	limiter, err := getRateLimiter(auth.Email())
 	if err != nil {

--- a/triggers/bernard/limiter.go
+++ b/triggers/bernard/limiter.go
@@ -12,7 +12,7 @@ const (
 	// how many requests can be sent per second by all drives using the same account file
 	requestLimit = 8
 	// how many drives can run at once (at the trigger level), e.g. 2 triggers, with 5 drives each.
-	syncLimit    = 5
+	syncLimit = 5
 )
 
 type rateLimiter struct {


### PR DESCRIPTION
## Details

- Add `scan-delay` configuration option that can be used to alter the default delay of 5 seconds between scan requests being sent to targets.
- Database adjustments to attempt resolving database locking issues.
