### PR TITLE
refactor: use timestamp for logs

### DIFF
--- a/cmd/autoscan/main.go
+++ b/cmd/autoscan/main.go
@@ -116,8 +116,10 @@ func main() {
 	}
 
 	logger := log.Output(io.MultiWriter(zerolog.ConsoleWriter{
-		Out: os.Stderr,
+		TimeFormat: time.Stamp,
+		Out:        os.Stderr,
 	}, zerolog.ConsoleWriter{
+		TimeFormat: time.Stamp,
 		Out: &lumberjack.Logger{
 			Filename:   cli.Log,
 			MaxSize:    5,


### PR DESCRIPTION
Switch from the `time.Kitchen` time format to `time.Stamp`