### PR TITLE
fix(targets/plex): add trailing slash to libraries

### DIFF
--- a/targets/plex/api.go
+++ b/targets/plex/api.go
@@ -127,10 +127,17 @@ func (c apiClient) Libraries() ([]library, error) {
 	libraries := make([]library, 0)
 	for _, lib := range resp.MediaContainer.Libraries {
 		for _, folder := range lib.Sections {
+			libPath := folder.Path
+
+			// Add trailing slash if there is none.
+			if len(libPath) > 0 && libPath[len(libPath)-1] != '/' {
+				libPath += "/"
+			}
+
 			libraries = append(libraries, library{
 				Name: lib.Name,
 				ID:   lib.ID,
-				Path: folder.Path,
+				Path: libPath,
 			})
 		}
 	}


### PR DESCRIPTION
Adds a trailing slash `/` to all library paths in the Plex target. This should resolve multiple libraries from matching if they share the same initial characters. Closes #101 