### PR TITLE
feat: health check

### DIFF
--- a/cmd/autoscan/health.go
+++ b/cmd/autoscan/health.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"net/http"
+)
+
+func healthHandler(rw http.ResponseWriter, r *http.Request) {
+	rw.WriteHeader(http.StatusOK)
+}

--- a/cmd/autoscan/main.go
+++ b/cmd/autoscan/main.go
@@ -242,6 +242,7 @@ func main() {
 
 	// http triggers
 	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthHandler)
 
 	manualTrigger, err := manual.New(c.Triggers.Manual)
 	if err != nil {


### PR DESCRIPTION
`/health` now always responds with `200` when Autoscan can receive incoming requests.