### PR TITLE
feat: custom hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,24 @@ targets:
           to: /data/ # path accessible by the Emby docker container (if applicable)
 ```
 
+## Other configuration options
+
+```yaml
+# Specify the port to listen on (3030 is the default when not specified)
+port: 3030
+```
+
+```yaml
+# Specify the host interface(s) to listen on (0.0.0.0 is the default when not specified)
+host:
+  - 127.0.0.1
+  - 172.19.185.13
+  - 192.168.0.1:5959
+```
+
+- If no port is specified, it will use the default port configured.
+- This configuration option is only needed if you have a requirement to listen to multiple interfaces.
+
 ## Other installation options
 
 ### Docker

--- a/cmd/autoscan/main.go
+++ b/cmd/autoscan/main.go
@@ -248,9 +248,9 @@ func main() {
 	for _, h := range c.Host {
 		go func(host string) {
 			log.Info().Msgf("Starting server on %s:%d", host, c.Port)
-			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", c.Host, c.Port), router); err != nil {
+			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", host, c.Port), router); err != nil {
 				log.Fatal().
-					Str("addr", fmt.Sprintf("%s:%d", c.Host, c.Port)).
+					Str("addr", fmt.Sprintf("%s:%d", host, c.Port)).
 					Err(err).
 					Msg("Failed starting web server")
 			}

--- a/cmd/autoscan/main.go
+++ b/cmd/autoscan/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -247,10 +248,15 @@ func main() {
 
 	for _, h := range c.Host {
 		go func(host string) {
-			log.Info().Msgf("Starting server on %s:%d", host, c.Port)
-			if err := http.ListenAndServe(fmt.Sprintf("%s:%d", host, c.Port), router); err != nil {
+			addr := host
+			if !strings.Contains(addr, ":") {
+				addr = fmt.Sprintf("%s:%d", host, c.Port)
+			}
+
+			log.Info().Msgf("Starting server on %s", addr)
+			if err := http.ListenAndServe(addr, router); err != nil {
 				log.Fatal().
-					Str("addr", fmt.Sprintf("%s:%d", host, c.Port)).
+					Str("addr", addr).
 					Err(err).
 					Msg("Failed starting web server")
 			}


### PR DESCRIPTION
Allows you to specify the host interfaces to bind via the config.yml file:

```yml
host:
  - 127.0.0.1
  - 172.19.185.13
```

Closes #125