### PR TITLE
Fix compatibility with Plex 1.32.7.7484

### DIFF
--- a/targets/plex/api.go
+++ b/targets/plex/api.go
@@ -148,7 +148,7 @@ func (c apiClient) Libraries() ([]library, error) {
 
 func (c apiClient) Scan(path string, libraryID int) error {
 	reqURL := autoscan.JoinURL(c.baseURL, "library", "sections", strconv.Itoa(libraryID), "refresh")
-	req, err := http.NewRequest("PUT", reqURL, nil)
+	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed creating scan request: %v: %w", err, autoscan.ErrFatal)
 	}


### PR DESCRIPTION
The `PUT` method was never documented in [the rare piece of documentation](https://support.plex.tv/articles/201638786-plex-media-server-url-commands/) that Plex provides, but it appears that they finally enforced it should be `GET` (even though it's against REST principles). On the assumption that the method was never checked on Plex's side previously, we will consider this a non-breaking change on Autoscan's side.

Closes #218 